### PR TITLE
Fix link to WT releases

### DIFF
--- a/website/docs/Download/watertap.mdx
+++ b/website/docs/Download/watertap.mdx
@@ -7,4 +7,4 @@ sidebar_position: 3
 
 import InstallerTable from '@site/src/components/InstallerTable/InstallerTable';
 
-<InstallerTable owner="prommis" repo="watertap"/>
+<InstallerTable owner="watertap-org" repo="watertap"/>


### PR DESCRIPTION
The link to the watertap releases was not fetching any of the existing releases.

Turns out it had prommis, instead of watertap-org as the GH organization. Once that's fixed the releases show up.